### PR TITLE
Fix misconfigured Dokka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.0.9.RELEASE' apply false
 	id 'io.spring.nohttp' version '0.0.5.RELEASE'
 	id 'org.jetbrains.kotlin.jvm' version '1.4.10' apply false
-	id 'org.jetbrains.dokka' version '1.4.10' apply false
+	id 'org.jetbrains.dokka' version '1.4.20.2'
 	id 'org.asciidoctor.jvm.convert' version '3.1.0'
 	id 'org.asciidoctor.jvm.pdf' version '3.1.0'
 	id 'de.undercouch.download' version '4.1.1'
@@ -289,6 +289,7 @@ configure(allprojects) { project ->
 		}
 		repositories {
 			mavenCentral()
+			mavenLocal()
 			maven { url "https://repo.spring.io/libs-spring-framework-build" }
 			maven { url "https://repo.spring.io/milestone" } // Reactor
 			maven { url "https://dl.bintray.com/kotlin/dokka" }
@@ -317,6 +318,17 @@ configure([rootProject] + javaProjects) { project ->
 	pluginManager.withPlugin("kotlin") {
 		apply plugin: "org.jetbrains.dokka"
 		apply from: "${rootDir}/gradle/docs-dokka.gradle"
+
+		configurations {
+			configure([dokkaHtmlPartialPlugin, dokkaHtmlPartialRuntime]) {
+				resolutionStrategy { // TODO: This will break when bumping Dokka version, spring-dependency-management plugin should be disabled for these configurations entirely
+					dependencySubstitution {
+						substitute module('org.jetbrains.kotlinx:kotlinx-coroutines-core') with module('org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1')
+						substitute module('org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm') with module('org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.4.1')
+					}
+				}
+			}
+		}
 		compileKotlin {
 			kotlinOptions {
 				jvmTarget = "1.8"

--- a/gradle/docs-dokka.gradle
+++ b/gradle/docs-dokka.gradle
@@ -1,20 +1,21 @@
-tasks.named("dokkaHtml") {
-	outputDirectory.set(new File(buildDir, "docs/kdoc"))
-	dokkaSourceSets {
-		configureEach {
-			sourceRoots.setFrom(file("src/main/kotlin")) // Does not work
-			externalDocumentationLink {
-				url.set(new URL("https://docs.spring.io/spring-framework/docs/current/javadoc-api/"))
-			}
-			externalDocumentationLink {
-				url.set(new URL("https://projectreactor.io/docs/core/release/api/"))
-			}
-			externalDocumentationLink {
-				url.set(new URL("https://www.reactive-streams.org/reactive-streams-1.0.1-javadoc/"))
-			}
-			externalDocumentationLink {
-				url.set(new URL("https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/"))
-			}
-		}
-	}
+tasks.findByName("dokkaHtmlPartial")?.configure {
+    outputDirectory.set(new File(buildDir, "docs/kdoc"))
+    dokkaSourceSets {
+        configureEach {
+            sourceRoots.setFrom(file("src/main/kotlin"))
+            classpath.from(file("build/classes/java/main"))
+            externalDocumentationLink {
+                url.set(new URL("https://docs.spring.io/spring-framework/docs/current/javadoc-api/"))
+            }
+            externalDocumentationLink {
+                url.set(new URL("https://projectreactor.io/docs/core/release/api/"))
+            }
+            externalDocumentationLink {
+                url.set(new URL("https://www.reactive-streams.org/reactive-streams-1.0.1-javadoc/"))
+            }
+            externalDocumentationLink {
+                url.set(new URL("https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/"))
+            }
+        }
+    }
 }

--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -60,6 +60,7 @@ task api(type: Javadoc) {
 
 tasks.named("dokkaHtmlMultiModule") {
 	outputDirectory.set(new File(buildDir, "docs/kdoc"))
+	it.dependsOn assemble
 }
 
 task downloadResources(type: Download) {


### PR DESCRIPTION
Please note: this PR will only work with the next Dokka release, after https://github.com/Kotlin/dokka/pull/1695 is merged. 

There were three main issues with the configuration:
1) Spring Dependency Management downgrades versions of Dokka's dependencies (most notably `kotlinx-coroutines`) which breaks the documentation runs. The correct fix would be to disable the dependency management plugin for all Dokka's configurations, but I can't find a way to do it. The correct version was thus hardcoded, as even the Gradle `dependencySubstitution` returns the downgraded versions (although there should be a way to get to the original ones)

2) Removing Java sources from `sourceRoots` by manually setting only Kotlin ones, broke the Dokka's classpath as Kotlin Plugin does not provide Java's generated classes anywhere that I'm aware of, and Kotlin compiler does not handle source files on its classpath at all

3) Lastly, `dokkaHtml` was configured instead of `dokkaHtmlPartial` for multimodule tasks 